### PR TITLE
kebab: overlay: Set status_bar_padding_top=28px

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -22,6 +22,9 @@
     <!-- the padding on the end of the statusbar -->
     <dimen name="status_bar_padding_end">48px</dimen>
 
+    <!-- the padding on the top of the statusbar (usually 0) -->
+    <dimen name="status_bar_padding_top">28px</dimen>
+
     <!-- Height of the status bar header bar when on Keyguard -->
     <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height</dimen>
 


### PR DESCRIPTION
Kang status bar top padding from PE/PE+ that used from OOS.

This supposed to fit also the status bar padding on pulled qs panel.